### PR TITLE
lit-50: offer next in res class passed to component handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,37 +2,105 @@
 
 # Litstack
 
-## Vision
-
-Using Angular and Spring boot design patterns, create a Typescript REST framework that developers already know how to use, keeping their code organized and concise, and pushing off all the express wiring to the library.
+Using Angular and Spring boot design patterns, Litstack is a Typescript REST framework that Angular/Spring Boot engineers already know how to use, keeping their code organized and concise, and pushing off the express wiring to the library.
 
 ## Getting Started
 
 ### Option 1: Clone the seed app
 
-You can [clone the litstack seed](https://github.com/codyjdalton/litstack-seed) and get started right away. Or you can set up a project manually.
+Follow the directions in the [the litstack seed](https://github.com/codyjdalton/litstack-seed) to get started right away.
 
 ### Option 2: Start with a blank slate
 
-Create a project and install the Litstack core library.
+Create a new project and install the Litstack core library.
 
 ```
-> mkdir my-project
-> cd my-project
-> npm init -y
-> npm install typescript -D
-> npm install @litstack/core
+> npm install @litstack/core --save
+```
+
+Make sure experimental decorators are on in your tsconfig.json at the root level:
+
+```json
+{
+    "compilerOptions": {
+        "experimentalDecorators": true
+    }
+}
+```
+
+For more on building, see the minimum configuration section below.
+
+## Bootstrapping
+
+Bootstrap app.module at the index.ts level:
+
+```typescript
+// in index.ts
+import { LitCompiler } from '@litstack/core/dist/compiler';
+
+import { AppModule } from './modules/app.module';
+
+LitCompiler.bootstrap(AppModule);
+```
+
+## Modules
+Modules can export component routes and package other modules.
+
+### Basic Module
+
+This module will export app.component's routes.
+
+```typescript
+// in app.module.ts
+import { LitModule } from '@litstack/core';
+
+import { AppComponent } from './app.component';
+
+@LitModule({
+    exports: [
+        AppComponent
+    ]
+})
+export class AppModule {
+}
+```
+
+### Module with Imports
+
+Modules can also import other modules with components:
+
+```typescript
+import { LitModule } from '@litstack/core';
+
+import { ItemsModule } from  './modules/items/items.module';
+import { OrdersModule } from  './modules/orders/orders.module';
+import { PeopleModule } from  './modules/people/people.module';
+import { VersionComponent } from  './components/version/version.component';
+
+@LitModule({
+    path: 'api', // will add all imported routes at '/api/..'
+    imports: [ 
+        ItemsModule,
+        PeopleModule,
+        OrdersModule
+    ],
+    exports: [
+        VersionComponent
+    ]
+})
+export class AppModule {
+}
 ```
 
 ## Components
-Components are used as route listeners.
+Components register route listeners:
 
 ### Basic Component
 
 ```typescript
 // in app.component.ts
 import { LitComponent } from '@litstack/core';
-import { HttpRequest, HttpResponse } from '@litstack/core/dist/http';
+import { HttpResponse } from '@litstack/core/dist/http';
 import { GetMapping } from '@litstack/core/dist/http/mappings';
 
 @LitComponent()
@@ -40,10 +108,8 @@ export class AppComponent {
 
     private message = 'Hello World!';
 
-    @GetMapping({
-        path: '' // GET / is routed to onHello
-    })
-    onHello(req: HttpRequest, res: HttpResponse): void {
+    @GetMapping() // defaults to '/'
+    onHello(res: HttpResponse): void {
         res.success({
             message: this.message
         });
@@ -51,12 +117,115 @@ export class AppComponent {
 }
 ```
 
-### Testing
+### Using path params
 
-Test your components [using supertest methods](https://github.com/visionmedia/supertest) and the Litstack TestBed:
+Specify params in the path:
+
+```typescript
+import { LitComponent } from '@litstack/core';
+import { HttpRequest, HttpResponse } from '@litstack/core/dist/http';
+import { GetMapping } from '@litstack/core/dist/http/mappings';
+
+@LitComponent()
+export class ItemsComponent {
+
+    @GetMapping({
+        path: ':id'
+    })
+    getItem(req: HttpRequest, res: HttpResponse): void {
+        res.success({
+            id: req.params.id
+        });
+    }
+}
+```
+
+### Chaining methods with next
+
+We can keep our route functionality isolated by using the "next" param:
+
+```typescript
+import { LitComponent } from '@litstack/core';
+import { HttpRequest, HttpResponse, HttpNext } from '@litstack/core/dist/http';
+import { PutMapping } from '@litstack/core/dist/http/mappings';
+
+@LitComponent()
+export class ItemsComponent {
+
+    // NOTE: The order matters here:
+    @PutMapping({
+        path: ':id'
+    })
+    updateItem(req: HttpRequest, res: HttpResponse, next: HttpNext) {
+
+        if(req.param.id === 'some-id') {
+
+            // do some update
+            res.success({ id: 'some-id' });
+            return;
+        }
+
+        next();
+    }
+
+    // same route as above, will run only if "next" is called
+    @PutMapping({
+        path: ':id'
+    })
+    updateItemErr(res: HttpResponse) {
+        
+        res.error(404);
+    }
+}
+```
+
+### Dependency Injection
+
+Services are a great place for business logic:
+
+```typescript
+// ./services/items.service
+import { LitService } from '@litstack/core';
+
+@LitService()
+export class ItemsService {
+
+    get description(): string {
+        return 'This is an item description';
+    }
+}
+```
+And then in our component:
+
+```typescript
+import { LitComponent } from '@litstack/core';
+import { HttpResponse } from '@litstack/core/dist/http';
+import { GetMapping } from '@litstack/core/dist/http/mappings';
+
+import { ItemsService } from './services/items.service';
+
+@LitComponent()
+export class ItemsComponent {
+
+    constructor(private itemsService: ItemsService) {}
+
+    @GetMapping()
+    getItems(res: HttpResponse) {
+        res.success({
+            description: this.itemsService.description
+        });
+    }
+}
+```
+
+## Testing
+
+Test components [using supertest methods](https://github.com/visionmedia/supertest) and the Litstack TestBed:
 
 ```typescript
 import { TestBed, LitComponentTest } from '@litstack/core/dist/testing';
+
+import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
 
@@ -88,217 +257,20 @@ describe('AppComponent', () => {
 });
 ```
 
-## Modules
-Modules can export component routes and package other modules.
+## Minimum Configuration
 
-### Basic Module
-
-This module will export app.component's routes.
-
-```typescript
-// in app.module.ts
-import { LitModule } from '@litstack/core';
-
-import { AppComponent } from './app.component';
-
-@LitModule({
-    exports: [
-        AppComponent
-    ]
-})
-export class AppModule {
-}
-```
-
-### Module with Imports
-
-Modules can also include imports.
-
-```typescript
-import { LitModule } from '@litstack/core';
-
-import { ItemsModule } from  './modules/items/items.module';
-import { OrdersModule } from  './modules/orders/orders.module';
-import { PeopleModule } from  './modules/people/people.module';
-import { VersionComponent } from  './components/version/version.component';
-
-@LitModule({
-    path: '', // this could be 'your-path' and all packaged routes
-    imports: [  // would be registered at '/your-path/...'
-        ItemsModule,
-        PeopleModule,
-        OrdersModule
-    ],
-    exports: [
-        VersionComponent
-    ]
-})
-export class AppModule {
-}
-```
-
-## Bootstrapping
-
-Bootstrap app.module at the index.ts level:
-
-```typescript
-// in index.ts
-import { LitCompiler } from '@litstack/core/dist/compiler';
-import { AppModule } from './modules/app.module';
-
-LitCompiler.bootstrap(AppModule);
-```
-
-## Services
-
-### Basic Service
-
-Services can be defined and injected into components:
-
-```typescript
-// in hello.service
-import { LitService } from '@litstack/core';
-
-@LitService()
-export class HelloService {
-    
-    getMessage(id: string) {
-        return {
-            message: 'Hello at ' + id
-        };
-    }
-}
-```
-
-```typescript
-// in app.component
-import { LitComponent } from '@litstack/core';
-import { HttpRequest, HttpResponse } from '@litstack/core/dist/http';
-import { GetMapping } from '@litstack/core/dist/http/mappings';
-
-import { HelloService } from './hello.service';
-
-@LitComponent()
-export class AppComponent {
-
-    constructor(private helloService: HelloService) {
-    }
-    /**
-     * @function sayHello
-     * @description return a success response with a message
-     */ 
-    @GetMapping({
-        path: ':id'
-    })
-    sayHello(req: HttpRequest, res: HttpResponse): void  {
-        res.success({
-            message: this.helloService.getMessage(req.params.id)
-        });
-    }
-}
-```
-
-## Full Component Example
-
-Notice the 'produces' param on the get mapping. That will add a 'Content-Type' header to the response.
-
-```typescript
-// people.component.ts
-
-// listack imports:
-import { LitComponent } from '@litstack/core';
-import { HttpRequest, HttpResponse } from '@litstack/core/dist/http';
-import { GetMapping,
-         PutMapping,
-         PostMapping } from '@litstack/core/dist/http/mappings';
-
-// custom imports:
-import { Person } from '../../common/models/person.model';
-import { PersonService } from '../../common/services/person.service';
-import { ResourceVersions } from '../common/enums/resource-versions.enum';
-
-@LitComponent()
-export class PeopleComponent {
-
-    constructor(private personService: PersonService) {
-    }
-
-    /**
-     * @function getPeople
-     * @description Return a list of people
-     */ 
-    @GetMapping({
-        produces: ResourceVersions.PEOPLE_V1 // Content-Type header
-    })
-    getPeople(req: HttpRequest, res: HttpResponse): void  {
-        this.personService.fetchAll()
-            .subscribe(
-                (people: Person[]) => res.success(people),
-                (err) => res.error(401)
-            )
-    }
-
-    /**
-     * @function getPerson
-     * @description Return a single person
-     */ 
-    @GetMapping({
-        path: ':id',
-        produces: ResourceVersions.PEOPLE_V1 // Content-Type header
-    })
-    getPerson(req: HttpRequest, res: HttpResponse): void  {
-        this.personService.fetchById(req.params.id)
-            .subscribe(
-                (people: Person[]) => res.success(people),
-                (err) => res.error(401)
-            )
-    }
-
-    /**
-     * @function updatePerson
-     * @description Update a 'person' record
-     */
-    @PutMapping({
-        path: ':id', // accessed by PUT /people/:id
-        produces: ResourceVersions.PERSON_V1 // Content-Type header
-    })
-    updatePerson(req: HttpRequest, res: HttpResponse): void  {
-        this.personService.update(req.params.id, req.body)
-            .subscribe(
-                (person: Person) => res.success(person),
-                (err) => res.error(404)
-            )
-    }
-
-    /**
-     * @function createPerson
-     * @description Create a 'person' record
-     */
-    @PostMapping({
-        produces: ResourceVersions.PERSON_V1 // Content-Type header
-    })
-    createPerson(req: HttpRequest, res: HttpResponse): void  {
-        // update person
-        this.personService.update(null, req.body)
-            .subscribe(
-                (person: Person) => res.created(person),
-                (err) => res.error(404)
-            )
-    }
-}
-```
-
-## Building the app
-
-Your build process can be customized to your needs, but a minimum configuration could look like this:
+The build process can be customized to the needs of the project, but a minimum configuration could look like this:
 
 ```
+> mkdir my-project
+> cd my-project
+> npm init -y
+> npm install @litstack/core --save
+> npm install typescript -D
 > npm install ts-node -D
-> npm install @types/node -D
-> npm install @types/express -D
 ```
 
-Change the following in your package.json:
+Change the following in package.json:
 
 ```json
 {
@@ -309,7 +281,7 @@ Change the following in your package.json:
 }
 ```
 
-You'll also need a tsconfig.json.
+A tsconfig.json could look like this:
 
 ```json
 {
@@ -329,7 +301,7 @@ You'll also need a tsconfig.json.
 }
 ```
 
-Now you should be able to run your app:
+Now, run the app:
 
 ```
 > npm start

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Using Angular and Spring boot design patterns, Litstack is a Typescript REST fra
 
 ### Option 1: Clone the seed app
 
-Follow the directions in the [the litstack seed](https://github.com/codyjdalton/litstack-seed) to get started right away.
+Follow the directions in [the litstack seed](https://github.com/codyjdalton/litstack-seed) to get started right away.
 
 ### Option 2: Start with a blank slate
 

--- a/lib/compiler/classes/injector.class.spec.ts
+++ b/lib/compiler/classes/injector.class.spec.ts
@@ -106,4 +106,31 @@ describe('Class: Injector', () => {
         expect(metadata.path).to.equal(expectedMetadata.path);
         expect(metadata.produces).to.equal(expectedMetadata.produces);
     });
+
+    it('should return a list of param types', () => {
+
+        @LitComponent()
+        class TestComponent {
+
+            @GetMapping()
+            resOnly(res) {
+                
+            }
+
+            @GetMapping()
+            reqRes(req, res) {
+
+            }
+
+            @GetMapping()
+            reqResNext(req, res, next) {
+                
+            }
+        }
+
+        expect(Injector.getParams(TestComponent, 'noMethod').length).to.equal(0);
+        expect(Injector.getParams(TestComponent, 'resOnly').length).to.equal(1);
+        expect(Injector.getParams(TestComponent, 'reqRes').length).to.equal(2);
+        expect(Injector.getParams(TestComponent, 'reqResNext').length).to.equal(3);
+    });
   });

--- a/lib/compiler/classes/injector.class.ts
+++ b/lib/compiler/classes/injector.class.ts
@@ -56,4 +56,8 @@ export const Injector = new class {
       }, {}
     );
   }
+
+  getParams(target: Type<any>, propertyKey: string) {
+    return Reflect.getMetadata('design:paramtypes', target.prototype, propertyKey) || [];
+  }
 };

--- a/lib/compiler/components/default.component.ts
+++ b/lib/compiler/components/default.component.ts
@@ -1,0 +1,14 @@
+/**
+ * default.component
+ */
+import { HttpResponse } from "../../http";
+import { LitComponent } from "../..";
+
+@LitComponent()
+export class DefaultComponent {
+
+    notImplemented(res: HttpResponse): void {
+        
+        res.errored(501);
+    }
+}

--- a/lib/http/classes/response.class.ts
+++ b/lib/http/classes/response.class.ts
@@ -4,16 +4,18 @@
  * The HTTP response class is a wrapper for the
  * http response object
  */
-
 import express = require('express');
+import defaultResponse = require('default-response');
 
 import { Response } from '../models/response.model';
 import { Injector } from '../../compiler/classes/injector.class';
 
-// @TODO MOVE THIS TO ITS OWN FILE!!!!
+// @TODO MOVE THESE TO THEIR OWN FILE!!!!
 export interface metaConfig {
     produces?: string;
 }
+
+export type Body = Object | any[] | null;
 
 export class HttpResponse {
 
@@ -33,7 +35,7 @@ export class HttpResponse {
 
     /**
      * @function success
-     * @param {any} obj
+     * @param {Body} body
      * 
      * Usage:
      * res.success({ id: 'some-id' })
@@ -41,17 +43,14 @@ export class HttpResponse {
      * Would respond with 200 OK
      * { id: 'some-id' }
      */ 
-    success(obj: Object | any[], status: number = 200): void {
+    success(body: Body, status: number = 200): void {
 
-        // set the produces header if one exists 
-        this.setProduces();
-
-        this.response.status(status).json(obj);
+        this.respond(status, body);
     }
 
     /**
      * @function created
-     * @param {any} obj
+     * @param {Body} body
      * 
      * Usage:
      * res.created({ id: 'some-id' })
@@ -59,13 +58,14 @@ export class HttpResponse {
      * Would respond with 201 Created
      * { id: 'some-id' }
      */ 
-    created(obj: Object | any[]): void {
-        this.success(obj, 201);
+    created(body: Body): void {
+        this.success(body, 201);
     }
 
     /**
      * @function errored
-     * @param {any} obj
+     * @param {number} status
+     * @param {Object | any[]} body
      * 
      * Usage:
      * res.errored(404, { message: 'The resource was not found on this server' })
@@ -73,7 +73,16 @@ export class HttpResponse {
      * Would respond with 404 Created
      * { message: 'The resource was not found on this server' }
      */ 
-    errored(status: number | null = null, messageObj: Object = {}): void {
-        this.response.status(status || 500).json(messageObj);
+    errored(status: number = 500, body: Body = null): void {
+
+        this.respond(status, body);
+    }
+
+    private respond(status: number, body: Object | any[] | null): void {
+
+        // set the produces header if one exists 
+        this.setProduces();
+
+        this.response.status(status).json(body || defaultResponse.status(status));
     }
 }

--- a/lib/http/index.ts
+++ b/lib/http/index.ts
@@ -1,4 +1,5 @@
 
 /* Export mapping decorator */
 export * from './models/request.model';
+export * from './models/next.model';
 export * from './classes/response.class';

--- a/lib/http/models/next.model.ts
+++ b/lib/http/models/next.model.ts
@@ -1,0 +1,12 @@
+/**
+ * next.model
+ */
+import express = require('express');
+
+/**
+ * This type is to emulate the supported types
+ * wrapping around an express next method
+ */
+export interface HttpNext extends express.NextFunction {
+    // ..
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@litstack/core",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -115,7 +115,6 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true,
       "requires": {
         "co": "^4.6.0",
         "fast-deep-equal": "^1.0.0",
@@ -155,14 +154,12 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -178,14 +175,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-      "dev": true
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -197,7 +192,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -231,7 +225,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "dev": true,
       "requires": {
         "hoek": "4.x.x"
       }
@@ -266,8 +259,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.1.2",
@@ -320,8 +312,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "color-convert": {
       "version": "1.9.1",
@@ -410,7 +401,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "dev": true,
       "requires": {
         "boom": "5.x.x"
       },
@@ -419,7 +409,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
           "requires": {
             "hoek": "4.x.x"
           }
@@ -430,7 +419,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -451,6 +439,11 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "default-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/default-response/-/default-response-1.0.1.tgz",
+      "integrity": "sha1-1HuDsG/0TtR2LU5rfzFhEx3u5Vo="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -477,7 +470,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "~0.1.0"
@@ -623,20 +615,17 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "finalhandler": {
       "version": "1.1.1",
@@ -662,8 +651,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.2",
@@ -706,7 +694,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -734,14 +721,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "dev": true,
       "requires": {
         "ajv": "^5.1.0",
         "har-schema": "^2.0.0"
@@ -757,7 +742,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "dev": true,
       "requires": {
         "boom": "4.x.x",
         "cryptiles": "3.x.x",
@@ -774,8 +758,7 @@
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-      "dev": true
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "http-errors": {
       "version": "1.6.3",
@@ -792,7 +775,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -830,8 +812,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
       "version": "1.0.0",
@@ -841,8 +822,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "js-yaml": {
       "version": "3.11.0",
@@ -858,32 +838,27 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
       "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -3647,8 +3622,7 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -3692,8 +3666,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -3712,8 +3685,7 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
       "version": "6.5.1",
@@ -3756,10 +3728,9 @@
       "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A=="
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
-      "dev": true,
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
+      "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.6.0",
@@ -3779,7 +3750,6 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.1",
         "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
         "tough-cookie": "~2.3.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.1.0"
@@ -3850,7 +3820,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "dev": true,
       "requires": {
         "hoek": "4.x.x"
       }
@@ -3881,7 +3850,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -3905,12 +3873,6 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
     },
     "superagent": {
       "version": "3.8.2",
@@ -3961,7 +3923,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "dev": true,
       "requires": {
         "punycode": "^1.4.1"
       }
@@ -3991,7 +3952,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -4000,7 +3960,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
       "optional": true
     },
     "type-detect": {
@@ -4042,8 +4001,7 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-      "dev": true
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "vary": {
       "version": "1.1.2",
@@ -4054,7 +4012,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@litstack/core",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Typescript REST Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
     "body-parser": "^1.18.3",
+    "default-response": "^1.0.1",
     "express": "^4.16.3",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^6.1.0",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,5 @@
 --require ts-node/register
 --require source-map-support/register
 --full-trace
+--bail
 **/*.spec.ts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pass next to component handler methods

Supports:
```typescript
someMappingMethod(res)
someMappingMethod(req, res)
someMappingMethod(req, res, next)
```

## Motivation and Context
Closes https://github.com/codyjdalton/litstack/issues/50

## How Has This Been Tested?
Added tests to compiler and http response class

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
